### PR TITLE
docs: fix documentation to match current codebase

### DIFF
--- a/docs/guides/api-reference.md
+++ b/docs/guides/api-reference.md
@@ -142,10 +142,15 @@ Semantic search using vector embeddings + keyword hybrid scoring. Returns result
     "keyword_score": 0.95,
     "card": { "name": "Code Review Agent", "..." : "..." },
     "trust": {
-      "reputation_score": 75,
-      "stake_score": 50,
-      "endorsement_score": 30,
-      "composite_score": 60
+      "did": "did:agentme:base:agent-001",
+      "score": 0.60,
+      "reputation": 0.75,
+      "stake_score": 0.50,
+      "endorsement_score": 0.30,
+      "stake_amount": 1000000000,
+      "successful_transactions": 42,
+      "failed_transactions": 3,
+      "endorsement_count": 5
     }
   }
 ]
@@ -243,10 +248,15 @@ Get trust information for an agent. DID must be URL-encoded.
 **Response** `200 OK`
 ```json
 {
-  "reputation_score": 75,
-  "stake_score": 50,
-  "endorsement_score": 30,
-  "composite_score": 60
+  "did": "did:agentme:base:agent-001",
+  "score": 0.60,
+  "reputation": 0.75,
+  "stake_score": 0.50,
+  "endorsement_score": 0.30,
+  "stake_amount": 1000000000,
+  "successful_transactions": 42,
+  "failed_transactions": 3,
+  "endorsement_count": 5
 }
 ```
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -51,10 +51,12 @@ const did = 'did:agentme:base:my-agent-001';
 
 await client.registerAgent(
   {
+    id: did,
     name: 'Code Review Agent',
     description: 'Reviews code for bugs, security issues, and improvements',
+    version: '1.0.0',
     url: 'https://my-agent.example.com',
-    capabilities: [
+    skills: [
       { id: 'code-review', name: 'Code Review', description: 'Review code for bugs' },
       { id: 'debugging', name: 'Debugging', description: 'Debug and fix code issues' },
     ],
@@ -114,8 +116,8 @@ console.log(`Escrow created: ${escrowId}`);
 After the provider delivers:
 
 ```typescript
-// Provider confirms delivery
-await payment.confirmDelivery(escrowId);
+// Provider confirms delivery with output hash
+await payment.confirmDelivery(escrowId, keccak256(toHex(output)));
 
 // Client releases payment
 await payment.releaseEscrow(escrowId);
@@ -129,10 +131,10 @@ import { TrustClient } from '@agentme/sdk';
 const trust = new TrustClient(client);
 const details = await trust.getTrustDetails(did);
 
-console.log(`Reputation: ${details.reputationScore}%`);
-console.log(`Stake:      ${details.stakeScore}%`);
-console.log(`Endorsement:${details.endorsementScore}%`);
-console.log(`Composite:  ${details.compositeScore}%`);
+console.log(`Reputation: ${(details.scores.reputation * 100).toFixed(1)}%`);
+console.log(`Stake:      ${(details.scores.stake * 100).toFixed(1)}%`);
+console.log(`Endorsement:${(details.scores.endorsement * 100).toFixed(1)}%`);
+console.log(`Composite:  ${(details.scores.overall * 100).toFixed(1)}%`);
 ```
 
 ## Next Steps

--- a/docs/guides/sdk-guide.md
+++ b/docs/guides/sdk-guide.md
@@ -57,7 +57,7 @@ const didHash = keccak256(toHex(did));
 
 // Register on-chain
 await client.registerAgent(
-  { name: 'My Agent', description: '...', url: '...', capabilities: [] },
+  { id: did, name: 'My Agent', description: '...', version: '1.0.0', url: '...', skills: [] },
   'ipfs://QmCapabilityCardCID'
 );
 
@@ -153,8 +153,8 @@ const escrow = await payment.getEscrow(escrowId);
 console.log(`State: ${EscrowStateNames[escrow.state]}`);
 console.log(`Amount: ${formatUSDC(escrow.amount)} USDC`);
 
-// 3. Provider confirms delivery
-await payment.confirmDelivery(escrowId);
+// 3. Provider confirms delivery with output hash
+await payment.confirmDelivery(escrowId, keccak256(toHex(output)));
 
 // 4. Client releases payment
 await payment.releaseEscrow(escrowId);
@@ -187,15 +187,15 @@ import { TrustClient } from '@agentme/sdk';
 
 const trust = new TrustClient(client);
 
-// Composite score (0–10000 basis points)
+// Composite score (normalized 0.0–1.0)
 const score = await trust.getTrustScore('did:agentme:base:agent-001');
 
 // Detailed breakdown
 const details = await trust.getTrustDetails('did:agentme:base:agent-001');
-console.log(`Reputation:  ${details.reputationScore / 100}%`);
-console.log(`Stake:       ${details.stakeScore / 100}%`);
-console.log(`Endorsement: ${details.endorsementScore / 100}%`);
-console.log(`Composite:   ${details.compositeScore / 100}%`);
+console.log(`Reputation:  ${(details.scores.reputation * 100).toFixed(1)}%`);
+console.log(`Stake:       ${(details.scores.stake * 100).toFixed(1)}%`);
+console.log(`Endorsement: ${(details.scores.endorsement * 100).toFixed(1)}%`);
+console.log(`Composite:   ${(details.scores.overall * 100).toFixed(1)}%`);
 ```
 
 ---


### PR DESCRIPTION
Oprava 9 nesrovnalostí ve 3 docs souborech:

**getting-started.md:**
- CapabilityCard: přidány povinná pole id, version, skills (místo capabilities)
- confirmDelivery: přidán chybějící parametr outputHash
- TrustDetails: opravena struktura na details.scores.*

**sdk-guide.md:**
- Stejné CapabilityCard a TrustDetails opravy
- Trust score popis: 0-10000 basis points → normalizované 0.0-1.0

**api-reference.md:**
- TrustInfo field names opraveny (reputation_score → reputation, composite_score → score)
- Doplněna chybějící pole (did, stake_amount, successful_transactions)