### PR TITLE
ci: fix Claude Code review permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -37,9 +37,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          review_comment: true
+          prompt: |
+            Review this pull request. Focus on:
+            - Security issues and vulnerabilities
+            - Logic errors and bugs
+            - Code quality and best practices
+            - Consistency with existing codebase patterns
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- Fix workflow permissions from `read` to `write` for `pull-requests` and `issues` so Claude can post review comments
- Simplify auto-review workflow with inline prompt focused on security, bugs, code quality
- Remove unnecessary plugin configuration from review workflow

## Test plan
- [ ] Verify Claude Code review triggers on new PRs
- [ ] Verify @claude mentions work in PR comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)